### PR TITLE
Fix types declaration field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Fetch wrap to add AWS v4 signature to the request",
   "main": "dist/index.js",
-  "type": "dist/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "prepublish": "tsc",
     "build": "tsc",


### PR DESCRIPTION
The `type` field is used to set the module format [1], while the `types` field is used to set type declarations [2].

[1]: https://nodejs.org/api/packages.html#packages_type
[2]:  https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package